### PR TITLE
Fix: Handle GET requests correctly and improve namespacing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,3 @@ gem "minitest", "~> 5.0"
 gem "rubocop", "~> 1.72"
 
 gem "webmock"
-
-gem "net/https"

--- a/Gemfile
+++ b/Gemfile
@@ -12,3 +12,5 @@ gem "minitest", "~> 5.0"
 gem "rubocop", "~> 1.72"
 
 gem "webmock"
+
+gem "net/https"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dify_client (0.1.0)
+    dify_client (0.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/dify/client.rb
+++ b/lib/dify/client.rb
@@ -2,95 +2,99 @@
 
 require_relative "client/version"
 
-class DifyClient
-  def initialize(api_key, base_url = "https://api.dify.ai/v1")
-    @api_key = api_key
-    @base_url = base_url
-  end
+module Dify
+  module Client
+    class DifyClient
+      def initialize(api_key, base_url = "https://api.dify.ai/v1")
+        @api_key = api_key
+        @base_url = base_url
+      end
 
-  def message_feedback(message_id, rating, user)
-    data = {
-      rating: rating,
-      user: user
-    }
-    _send_request("POST", "/messages/#{message_id}/feedbacks", data)
-  end
+      def message_feedback(message_id, rating, user)
+        data = {
+          rating: rating,
+          user: user
+        }
+        _send_request("POST", "/messages/#{message_id}/feedbacks", data)
+      end
 
-  def get_application_parameters(user)
-    params = { user: user }
-    _send_request("GET", "/parameters", nil, params)
-  end
+      def get_application_parameters(user)
+        params = { user: user }
+        _send_request("GET", "/parameters", nil, params)
+      end
 
-  def update_api_key(new_key)
-    @api_key = new_key
-  end
+      def update_api_key(new_key)
+        @api_key = new_key
+      end
 
-  private
+      private
 
-  def _send_request(method, endpoint, data = nil, params = nil, _stream: false)
-    uri = URI.parse("#{@base_url}#{endpoint}")
+      def _send_request(method, endpoint, data = nil, params = nil, _stream = false)
+        uri = URI.parse("#{@base_url}#{endpoint}")
 
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = true
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
 
-    headers = {
-      "Authorization" => "Bearer #{@api_key}",
-      "Content-Type" => "application/json"
-    }
+        headers = {
+          "Authorization" => "Bearer #{@api_key}",
+          "Content-Type" => "application/json"
+        }
 
-    if method == "GET"
-      uri.query = URI.encode_www_form(params) if params
-      request = Net::HTTP::Get.new(uri.request_uri, headers)
-    elsif method == "POST"
-      request = Net::HTTP::Post.new(uri.request_uri, headers)
-      request.body = data.to_json
+        if method == "GET"
+          uri.query = URI.encode_www_form(params) if params
+          request = Net::HTTP::Get.new(uri.request_uri, headers)
+        elsif method == "POST"
+          request = Net::HTTP::Post.new(uri.request_uri, headers)
+          request.body = data.to_json
+        end
+
+        http.request(request)
+      end
     end
 
-    http.request(request)
-  end
-end
+    class CompletionClient < DifyClient
+      def create_completion_message(inputs, query, response_mode, user)
+        data = {
+          inputs: inputs,
+          query: query,
+          response_mode: response_mode,
+          user: user
+        }
+        _send_request("POST", "/completion-messages", data, nil, response_mode == "streaming")
+      end
+    end
 
-class CompletionClient < DifyClient
-  def create_completion_message(inputs, query, response_mode, user)
-    data = {
-      inputs: inputs,
-      query: query,
-      response_mode: response_mode,
-      user: user
-    }
-    _send_request("POST", "/completion-messages", data, nil, response_mode == "streaming")
-  end
-end
+    class ChatClient < DifyClient
+      def create_chat_message(inputs, query, user, response_mode = "blocking", conversation_id = nil)
+        data = {
+          inputs: inputs,
+          query: query,
+          user: user,
+          response_mode: response_mode
+        }
+        data[:conversation_id] = conversation_id if conversation_id
 
-class ChatClient < DifyClient
-  def create_chat_message(inputs, query, user, response_mode = "blocking", conversation_id = nil)
-    data = {
-      inputs: inputs,
-      query: query,
-      user: user,
-      response_mode: response_mode
-    }
-    data[:conversation_id] = conversation_id if conversation_id
+        _send_request("POST", "/chat-messages", data, nil, response_mode == "streaming")
+      end
 
-    _send_request("POST", "/chat-messages", data, nil, response_mode == "streaming")
-  end
+      def get_conversation_messages(user, conversation_id = nil, first_id = nil, limit = nil)
+        params = { user: user }
+        params[:conversation_id] = conversation_id if conversation_id
+        params[:first_id] = first_id if first_id
+        params[:limit] = limit if limit
 
-  def get_conversation_messages(user, conversation_id = nil, first_id = nil, limit = nil)
-    params = { user: user }
-    params[:conversation_id] = conversation_id if conversation_id
-    params[:first_id] = first_id if first_id
-    params[:limit] = limit if limit
+        _send_request("GET", "/messages", nil, params)
+      end
 
-    _send_request("GET", "/messages", nil, params)
-  end
+      def get_conversations(user, last_id = nil, limit = nil, pinned = nil)
+        params = { user: user, last_id: last_id, limit: limit, pinned: pinned }
+        _send_request("GET", "/conversations", nil, params)
+      end
 
-  def get_conversations(user, last_id = nil, limit = nil, pinned = nil)
-    params = { user: user, last_id: last_id, limit: limit, pinned: pinned }
-    _send_request("GET", "/conversations", nil, params)
-  end
-
-  def rename_conversation(conversation_id, name, user)
-    data = { name: name, user: user }
-    _send_request("POST", "/conversations/#{conversation_id}/name", data)
+      def rename_conversation(conversation_id, name, user)
+        data = { name: name, user: user }
+        _send_request("POST", "/conversations/#{conversation_id}/name", data)
+      end
+    end
   end
 end

--- a/lib/dify/client.rb
+++ b/lib/dify/client.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "client/version"
+require "net/https"
+require "json"
 
 module Dify
   module Client

--- a/lib/dify/client/version.rb
+++ b/lib/dify/client/version.rb
@@ -2,6 +2,6 @@
 
 module Dify
   module Client
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
This pull request addresses a bug that caused GET requests to fail and improves the overall structure of the codebase by introducing proper namespacing. The gem version has been bumped to 0.1.1 to reflect these changes.

  Changes Included:

   - Bug Fix: Corrected an issue in the _send_request method where GET requests would cause critical failure due to a misplaced http.request call. The fix ensures that both GET and POST requests are now handled correctly.
   - Refactoring: All client classes (DifyClient, CompletionClient, and ChatClient) are now properly namespaced under the Dify::Client module. This improves code organization and prevents potential naming conflicts with other gems.
   - Dependencies: Added explicit require "net/https" and require "json" statements to ensure all necessary libraries are loaded.
   - Version Bump: Increased the gem version from 0.1.0 to 0.1.1, because thing from gem install and your github are not the same.